### PR TITLE
Fix git login problem for purescript-halogen dep.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,6 +12,6 @@
   ],
   "dependencies": {
     "purescript-console": "^0.1.0",
-    "purescript-halogen": "git@github.com:slamdata/purescript-halogen.git#master"
+    "purescript-halogen": "purescript-halogen#master"
   }
 }


### PR DESCRIPTION
I was getting the following error when using the original url:

```
fatal: Could not read from remote repository.
Please make sure you have the correct access rights and the repository exists.
```
