### PR TITLE
Fixes broken link to part 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ The repository is accompanied by a series of blog posts explaining the code and 
 1. [Elm vs PureScript I: War of the Hello, Worlds](http://www.parsonsmatt.org/programming/2015/10/03/elm_vs_purescript.html)
 2. [Elm vs PureScript II](http://www.parsonsmatt.org/programming/2015/10/05/elm_vs_purescript_ii.html)
 3. [Elm Architecture in PureScript III: Dynamic Lists of Counters](http://www.parsonsmatt.org/programming/2015/10/10/elm_architecture_in_purescript_iii.html)
-4. [Elm Architecture in PureScript IV: Effects](http://www.parsonsmatt.org/programming/2015/10/11/elm_architecture_in_purescript_iv:_effects.html)
+4. [Elm Architecture in PureScript IV: Effects](http://www.parsonsmatt.org/programming/2015/10/11/elm_architecture_in_purescript_iv_effects.html)
 
 


### PR DESCRIPTION
The link for 'Elm Architecture in Purescript IV' was broken with an extraneous ':' character
