### PR TITLE
Update Readme.md with correct version of pulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ A port of the [Elm Architecture Tutorial](https://github.com/evancz/elm-architec
 ## Getting Started:
 
 1. Ensure that you've got PureScript 0.7.6 installed. (has also been tested with 0.8RC)
-2. Ensure that you've got pulp installed.
+2. Ensure that you've got pulp 8.x installed (`npm install pulp@8`)
 3. Run `npm install` to get the virtual-dom dependency loaded
-4. Run `pulp dep install` to get the PureScript dependencies loaded
+4. Run `pulp dep install` to get the PureScript dependencies loaded.
 5. Run `pulp server` to run the server and access it at `http://localhost:1337`
 
 ## Blog posts:


### PR DESCRIPTION
Later versions of pulp will not work with purescript 0.7.6
Also pulp dep is deprecated in later versions.